### PR TITLE
Causemos google trends

### DIFF
--- a/google-trends/Dockerfile
+++ b/google-trends/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.8
+
+WORKDIR /
+
+COPY requirements.txt .
+
+RUN pip install -r requirements.txt
+
+COPY / .
+
+ENTRYPOINT ["python3","./trends.py"]

--- a/google-trends/README.md
+++ b/google-trends/README.md
@@ -2,14 +2,14 @@
 
 Install requirements with `pip3 install -r requirements.txt`.
 
-To run, execute `python3 trends.py --term=someterm --country=somecountry --state=somestate --output=some.csv` where:
+To run, execute `python3 trends.py --term=someterm --country=somecountry --admin1=someadmin1 --output=some.csv` where:
 
 <b>Required arguments:</b>
   - `--term=someterm` is the term of interest for obtaining a trend.
   - `--country=somecountry` is the country of interest.
   
 <b>Optional arguments:</b>  
-  - `--state=somestate` is the state or provincial level of interest; without a `state` Google Trends returns country-level results
+  - `--admin1=someadmin1` is the state or provincial level of interest; without a `state` Google Trends returns country-level results
   - `--output=some.csv` is your desired output filename, defaults to `trend.csv`
 
 Note: Any argument with a space requires quotes (such as `'Addis Ababa'` in the example below)
@@ -17,31 +17,33 @@ Note: Any argument with a space requires quotes (such as `'Addis Ababa'` in the 
 <b>Example:</b>
 
 ```
-python trends.py --term=teff --country=Ethiopia --state='Addis Ababa' --output=teff.csv
+python trends.py --term=teff --country=Ethiopia --admin1='Addis Ababa' --output=teff.csv
 ```
 
 Will yield a `.csv` file called `teff.csv` containing Google Trend information for Addis Ababa, Ethiopia:
 
-| timestamp   | iso_time    | value | description                      | country  | iso2 | state       |
-|-------------|-------------|-------|----------------------------------|----------|------|-------------|
-| 1451203200  | 2015-12-27  | 0     | Google Trends for teff for ET-AA | Ethiopia | ET   | Addis Ababa | 
-| 1451808000  | 2016-01-03  | 20    | Google Trends for teff for ET-AA | Ethiopia | ET   | Addis Ababa |
-| 1452412800  | 2016-01-10  | 57    | Google Trends for teff for ET-AA | Ethiopia | ET   | Addis Ababa |
-| 1453017600  | 2016-01-17  | 20    | Google Trends for teff for ET-AA | Ethiopia | ET   | Addis Ababa |
+
+| timestamp   | country   |admin1          | feature     | value | search_term |
+|-------------|-----------|----------------|-------------|-------|-------------|
+| 1451203200  | Ethiopia  | Oromia Region  | trend level | 1     | teff        | 
+| 1451808000  | Ethiopia  | Oromia Region  | trend level | 4     | teff        | 
+| 1452412800  | Ethiopia  | Oromia Region  | trend level | 4     | teff        | 
+| 1453017600  | Ethiopia  | Oromia Region  | trend level | 8     | teff        | 
 
 Where:
 
   - `timestamp`: Date of Google Trends data in epoch time; time of day is T08:00:00Z for all rows.
-  - `iso_time`: Date of Google Trends data in ISO-8601 (YYYY-MM-DD); time of day is T08:00:00Z for all rows.
+  - `country`: Country that Google Trends searched over for your `term` 
+  - `admin1`: admin1/State/province/woreda that Google Trends searched over for your `term`; `None` if no admin1 entered
+  - `feature`: Identifies the trend value.
   - `value`: a normalized score on how 'popular' your `term` is for your chosen geopolitical area versus other searches at a particular time
-  - `description`: Tags data with `term` and iso2 code for country-state (if state included)
-  - `country`: Country that Google Trends searched over for your `term`
-  - `state`: State/province/woreda that Google Trends searched over for your `term`; `None` if no state entered
-  - `iso2`: Country-level ISO 3166-1 alpha-2 abbreviation
+  - `search_term`: the keyword or phrase searched for
+
+
 
 
 ## ISO Country/State Names
-You can refer to `iso-codes.csv` to identify the country and state format you wish to use; the country/state must match the `iso-codes.csv` to include spelling, form, and capitalization. For instance: if you are interested in trend data for Amhara in Ethiopia, you must enter `--state='Amhara Region'`. If you wish to only get country-level trend data, do not include a `--state=` argument. Again, any argument you provide that has whitespace (such as `Addis Ababa` must be in quotes. Note that for some state-level searches, no trend information is available for certain terms.
+You can refer to `iso-codes.csv` to identify the country and state format you wish to use; the country/state must match the `iso-codes.csv` to include spelling, form, and capitalization. For instance: if you are interested in trend data for Amhara in Ethiopia, you must enter `--admin1='Amhara Region'`. If you wish to only get country-level trend data, do not include a `--admin1=` argument. Again, any argument you provide that has whitespace (such as `Addis Ababa` must be in quotes. Note that for some state-level searches, no trend information is available for certain terms.
 
 ## Docker Container
 
@@ -49,4 +51,4 @@ To run Google Trends in a Docker container:
 
 1. Build a local image in your working directory with `docker build -t trends .`
 2. Run the trends.py script with your desired arguments: 
-    `docker run -v ${PWD}:/output --rm trends --term=cafe --country=Italy --state=Campania --output=/output/cafe.csv`
+    `docker run -v ${PWD}:/output --rm trends --term=cafe --country=Italy --admin1=Campania --output=/output/cafe.csv`

--- a/google-trends/README.md
+++ b/google-trends/README.md
@@ -25,10 +25,10 @@ Will yield a `.csv` file called `teff.csv` containing Google Trend information f
 
 | timestamp   | country   |admin1          | feature     | value | search_term |
 |-------------|-----------|----------------|-------------|-------|-------------|
-| 1451203200  | Ethiopia  | Oromia Region  | trend level | 1     | teff        | 
-| 1451808000  | Ethiopia  | Oromia Region  | trend level | 4     | teff        | 
-| 1452412800  | Ethiopia  | Oromia Region  | trend level | 4     | teff        | 
-| 1453017600  | Ethiopia  | Oromia Region  | trend level | 8     | teff        | 
+| 1451203200  | Ethiopia  | Addis Ababa    | trend level | 1     | teff        | 
+| 1451808000  | Ethiopia  | Addis Ababa    | trend level | 4     | teff        | 
+| 1452412800  | Ethiopia  | Addis Ababa    | trend level | 4     | teff        | 
+| 1453017600  | Ethiopia  | Addis Ababa    | trend level | 8     | teff        | 
 
 Where:
 

--- a/google-trends/trends.py
+++ b/google-trends/trends.py
@@ -6,7 +6,7 @@ import os
 from time import time
 import numpy as np
 
-# Example CLI: python3 trends.py --term=election --country=Ethiopia --state='Addis Ababa' --output=election.csv
+# Example CLI: python3 trends.py --term='election' --country='Ethiopia' --state='Addis Ababa' --output=output.csv
 
 # For Docker testing:
 print(os.getcwd())
@@ -40,20 +40,24 @@ def iso_to_epoch(iso_time):
     return parsed_t.strftime("%s")
 
 
-def no_data(country, state, term):
+def no_data(term, country, state):
+    if country:
+        ctry = country
+    else:
+        ctry = np.nan
+    
     if state:
         admin1 = state
     else:
         admin1 = np.nan
-
-    empty_dict = {
-        "timestamp": [round(time() * 1000)],
-        "country": [country],
-        "admin1": [admin1],
-        "feature": ["trend level"],
-        "value": [np.nan],
-        "search_term": [f"{term}"],
-    }
+    
+    empty_dict = {'timestamp': [round(time()*1000)],
+                  'country': [ctry],
+                  'admin1': [admin1],
+                  'feature': ['trend level'],
+                  'value': [np.nan],
+                  'search_term':[f'{term}']
+                 }
 
     return pd.DataFrame(empty_dict)
 
@@ -71,7 +75,7 @@ def get_trend(term, country, state):
             print(
                 f"\nNo trend available for term:'{term}' country:'{country}' state:'{state}'\n"
             )
-            return no_data(country, state, term)
+            return no_data(term, country, state)
 
         # YES Google trend
         else:
@@ -118,7 +122,7 @@ def get_trend(term, country, state):
             "Invalid input:\n  Reference 'country_admin1.csv' for country/state names.\n  Note: Input parameters with spaces must be in quotes.\n"
         )
 
-        return no_data(country, state, term)
+        return no_data(term, country, state)
 
 
 if __name__ == "__main__":
@@ -152,8 +156,6 @@ if __name__ == "__main__":
     country = args.country
     state = args.state
     output = args.output
-    print(state)
-    print(type(state))
     trend = get_trend(term, country, state)
 
     if isinstance(trend, pd.DataFrame):

--- a/google-trends/trends.py
+++ b/google-trends/trends.py
@@ -3,6 +3,8 @@ import argparse
 import pandas as pd
 import dateutil.parser as dp
 import os
+from time import time
+import numpy as np
 
 # Example CLI: python3 trends.py --term=election --country=Ethiopia --state='Addis Ababa' --output=election.csv
 
@@ -10,16 +12,21 @@ import os
 print(os.getcwd())
 
 # Read in iso codes to build lookup dicts
-iso = pd.read_csv('iso-codes.csv')
-iso['country_code'] = iso['iso_code'].apply(lambda x: x.split('-')[0])
+iso = pd.read_csv("iso-codes.csv")
+iso["country_code"] = iso["iso_code"].apply(lambda x: x.split("-")[0])
 
 # Dict of Country to iso2 code (for country only trend search):
 ctry_to_iso_d = dict(zip(iso.countryLabel, iso.country_code))
 
 # Dict of (key=country, key=state) value = Country-state iso2 code (for country and state trend search)
-state_to_iso_d = iso.groupby('countryLabel').apply(lambda x: dict(zip(x['admin1Label'], x["iso_code"]))).to_dict()
+state_to_iso_d = (
+    iso.groupby("countryLabel")
+    .apply(lambda x: dict(zip(x["admin1Label"], x["iso_code"])))
+    .to_dict()
+)
 
-#convert user input to iso code:
+
+# convert user input to iso code:
 def input_to_iso(country, state=None):
     if state:
         geo = state_to_iso_d.get(country, {}).get(state, None)
@@ -27,73 +34,129 @@ def input_to_iso(country, state=None):
         geo = ctry_to_iso_d.get(country, None)
     return geo
 
+
 def iso_to_epoch(iso_time):
     parsed_t = dp.parse(iso_time)
-    return parsed_t.strftime('%s')
+    return parsed_t.strftime("%s")
+
+
+def no_data(country, state, term):
+    if state:
+        admin1 = state
+    else:
+        admin1 = np.nan
+
+    empty_dict = {
+        "timestamp": [round(time() * 1000)],
+        "country": [country],
+        "admin1": [admin1],
+        "feature": ["trend level"],
+        "value": [np.nan],
+        "search_term": [f"{term}"],
+    }
+
+    return pd.DataFrame(empty_dict)
+
 
 def get_trend(term, country, state):
 
     geo = input_to_iso(country, state)
-
     # geo can = None if the user enters invalid geo keys
     if geo:
-        pytrend = TrendReq(hl='en-US', tz=0, geo=geo)
+        pytrend = TrendReq(hl="en-US", tz=0, geo=geo)
         pytrend.build_payload(kw_list=[term])
         trend_df = pytrend.interest_over_time()
 
-        # NO Google Trend
-        if trend_df.shape[0] == 0:
-            print(f"\nNo trend available for term:'{term}' country:'{country}' state:'{state}'\n")
-            return None
+        if trend_df.empty:
+            print(
+                f"\nNo trend available for term:'{term}' country:'{country}' state:'{state}'\n"
+            )
+            return no_data(country, state, term)
 
         # YES Google trend
         else:
             trend_df = trend_df.reset_index()
-            trend_df = trend_df.rename(columns={'date': 'time', term: 'value'})
-            trend_df = trend_df.drop(columns='isPartial')
-            trend_df['description'] = f'Google Trends for the term {term} for the geography {geo}'
-            trend_df['country'] = country
-            trend_df['iso2'] = geo[:2]
-            
+            trend_df = trend_df.rename(columns={"date": "time", term: "value"})
+            trend_df = trend_df.drop(columns="isPartial")
+            trend_df["feature"] = "trend level"
+            trend_df["country"] = country
+            trend_df["search_term"] = f"{term}"
+
             if state:
-                trend_df['state'] = state
+                trend_df["admin1"] = state
 
             else:
-                trend_df['state'] = None
+                trend_df["admin1"] = np.nan
 
             # Convert to epoch time
             trend_df["timestamp"] = trend_df.time.apply(lambda x: iso_to_epoch(str(x)))
+            trend_df = trend_df.drop(columns="time")
 
             # reorder/rename columns and keep ISO time for comparison
             cols = list(trend_df)
-            cols.insert(0, cols.pop(cols.index('timestamp')))
-            trend_df = trend_df.reindex(columns= cols) 
-            trend_df.rename(columns={'time': 'iso_time'}, inplace=True)
+            cols.insert(0, cols.pop(cols.index("timestamp")))
+            trend_df = trend_df.reindex(columns=cols)
 
-            return trend_df
+            df = pd.DataFrame(
+                trend_df,
+                columns=[
+                    "timestamp",
+                    "country",
+                    "admin1",
+                    "feature",
+                    "value",
+                    "search_term",
+                ],
+            )
+
+            return df
 
     # bad user country/state inputs
     else:
         print(f"\nFor country:'{country}' state:'{state}'")
-        print("Invalid input:\n  Reference 'iso_codes.csv' for country/state names.\n  Note: Input parameters with spaces must be in quotes.\n")
-        return None
+        print(
+            "Invalid input:\n  Reference 'country_admin1.csv' for country/state names.\n  Note: Input parameters with spaces must be in quotes.\n"
+        )
+
+        return no_data(country, state, term)
+
 
 if __name__ == "__main__":
 
-    parser = argparse.ArgumentParser('Obtain Google Trends data')
-    parser.add_argument('--term', dest ='term', type=str, help='The term of interest.')
-    parser.add_argument('--country', dest ='country', type=str, default='Ethiopia', help='Required: Country of interest: "Ethiopia"')
-    parser.add_argument('--state', dest ='state', type=str, default=None, help='Optional: State/province/woreda of interest: "Addis Ababa"')
-    parser.add_argument('--output', dest ='output', type=str, default='trend.csv', help='The name of the desired output file.')
+    parser = argparse.ArgumentParser("Obtain Google Trends data")
+    parser.add_argument("--term", dest="term", type=str, help="The term of interest.")
+    parser.add_argument(
+        "--country",
+        dest="country",
+        type=str,
+        default="Ethiopia",
+        help='Required: Country of interest: "Ethiopia"',
+    )
+    parser.add_argument(
+        "--state",
+        dest="state",
+        type=str,
+        default=None,
+        help='Optional: State/province/woreda of interest: "Addis Ababa"',
+    )
+    parser.add_argument(
+        "--output",
+        dest="output",
+        type=str,
+        default="trend.csv",
+        help="The name of the desired output file.",
+    )
     args = parser.parse_args()
 
     term = args.term
     country = args.country
     state = args.state
     output = args.output
-
+    print(state)
+    print(type(state))
     trend = get_trend(term, country, state)
 
     if isinstance(trend, pd.DataFrame):
         trend.to_csv(args.output, index=False)
+        print(trend)
         print(f'\n"{output}" written to {os.getcwd()}\n')


### PR DESCRIPTION
What's New: 
- Changed output format to align with causemos compliant dataset
- Added "fail" feature to still produce a csv file (showing NaNs where appropriate) so downstream components don't fail in DMC.
- Changed CLI arg from `state` to `admin1`
- Updated README to reflect changes

How to test:
- clone and `cd open-indicators/google-trends`
- git checkout causemos_google_trends
- Run any version of:
`python3 trends.py --term='teff --country='Ethiopia' --state='Addis Ababa' --output=output.csv`
- Verify output.csv matches your search
- While note required here, in Shorthand annotation will require all CLI args to be in quotes (here only strings with spaces require quotes).
- `term` and `country` are required, `state` is optional and can be deleted (or for Shorthand annotation it will remain and be passed as an empty string if no admin1 is desired)

Known Issues:
Need to update Dojo/models/google-trends to match changes above